### PR TITLE
 Fix hospital map geolocation and default hospital selection

### DIFF
--- a/components/HospitalMap/HospitalMap.tsx
+++ b/components/HospitalMap/HospitalMap.tsx
@@ -11,36 +11,34 @@ import {
     getWaitTimeColor,
     hasCriticalCases,
     HONG_KONG_GEOFENCE,
-    isUserInHongKong,
     MAX_ZOOM,
     MIN_ZOOM,
 } from "@/lib/map"
-import { EnrichedHospitalData } from "@/types"
+import { Coordinates, EnrichedHospitalData } from "@/types"
 import * as turf from "@turf/turf"
-import { AlertCircle } from "lucide-react"
+import { AlertCircle, User } from "lucide-react"
 import "mapbox-gl/dist/mapbox-gl.css"
 import { useTheme } from "next-themes"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { useGeolocated } from "react-geolocated"
 import Map, { MapRef, Marker, ViewState } from "react-map-gl/mapbox"
 
 interface HospitalMapProps {
     onHospitalSelect?: (hospital: EnrichedHospitalData | null) => void
+    userCoords?: Coordinates | null
+    isOpen?: boolean
 }
 
-export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
-    const { coords, isGeolocationEnabled } = useGeolocated({
-        suppressLocationOnMount: true,
-    })
+export function HospitalMap({
+    onHospitalSelect,
+    userCoords = null,
+    isOpen = true,
+}: HospitalMapProps) {
     const { data: waitTimesData } = useHospitalWaitTimes()
     const { lang } = useLanguage()
     const { theme, resolvedTheme } = useTheme()
 
-    // Determine current theme for color calculations
     const currentTheme = (resolvedTheme || theme || "light") as "light" | "dark"
 
-    // Determine map style based on theme
-    // resolvedTheme handles "system" theme by resolving to "light" or "dark"
     const mapStyle = useMemo(() => {
         const currentTheme = resolvedTheme || theme || "light"
         return currentTheme === "dark"
@@ -48,21 +46,10 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
             : "mapbox://styles/mapbox/light-v11"
     }, [theme, resolvedTheme])
 
-    // Determine user location (use geolocation if available and in Hong Kong, otherwise default)
     const userLocation = useMemo(() => {
-        if (isGeolocationEnabled && coords) {
-            const userCoords = {
-                longitude: coords.longitude,
-                latitude: coords.latitude,
-            }
-            if (isUserInHongKong(userCoords)) {
-                return userCoords
-            }
-        }
-        return DEFAULT_COORDINATES
-    }, [isGeolocationEnabled, coords])
+        return userCoords ?? DEFAULT_COORDINATES
+    }, [userCoords])
 
-    // Initial view state - computed from userLocation
     const initialViewState = useMemo(
         () => ({
             longitude: userLocation.longitude,
@@ -74,8 +61,38 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
 
     const [viewState, setViewState] = useState(initialViewState)
     const mapRef = useRef<MapRef>(null)
+    const hasCenteredOnUser = useRef(false)
 
-    // Resize map when container becomes visible (fixes dialog opening issue)
+    useEffect(() => {
+        if (!isOpen) {
+            hasCenteredOnUser.current = false
+        }
+    }, [isOpen])
+
+    const flyToUser = useCallback(() => {
+        if (!userCoords || !mapRef.current || hasCenteredOnUser.current) {
+            return false
+        }
+        hasCenteredOnUser.current = true
+        mapRef.current.flyTo({
+            center: [userCoords.longitude, userCoords.latitude],
+            zoom: 12,
+            duration: 800,
+        })
+        return true
+    }, [userCoords])
+
+    useEffect(() => {
+        if (!userCoords || hasCenteredOnUser.current) {
+            return
+        }
+        if (flyToUser()) {
+            return
+        }
+        const timer = setTimeout(flyToUser, 150)
+        return () => clearTimeout(timer)
+    }, [userCoords, flyToUser])
+
     useEffect(() => {
         const resizeMap = () => {
             if (mapRef.current) {
@@ -83,11 +100,9 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
             }
         }
 
-        // Initial resize with delay to ensure container is fully rendered
         const timer1 = setTimeout(resizeMap, 100)
-        const timer2 = setTimeout(resizeMap, 300) // Second attempt for slower renders
+        const timer2 = setTimeout(resizeMap, 300)
 
-        // Also resize when window resizes
         window.addEventListener("resize", resizeMap)
 
         return () => {
@@ -97,23 +112,18 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
         }
     }, [])
 
-    // Use enriched hospital data (already merged with wait times from the hook)
     const enrichedHospitals = useMemo(() => {
         return waitTimesData?.waitTimes ?? []
     }, [waitTimesData])
 
-    // Calculate distances using Mapbox Matrix API
     const { distances: distanceData } = useMapboxDistance(
-        isGeolocationEnabled && coords
-            ? { longitude: coords.longitude, latitude: coords.latitude }
-            : null,
+        userCoords,
         enrichedHospitals.map((h) => ({
             slug: h.slug,
             coordinates: h.coordinates,
         }))
     )
 
-    // Selected hospital - default to first hospital
     const defaultSelectedHospital = useMemo(() => {
         return enrichedHospitals.length > 0 ? enrichedHospitals[0] : null
     }, [enrichedHospitals])
@@ -121,10 +131,8 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
     const [userSelectedHospital, setUserSelectedHospital] =
         useState<EnrichedHospitalData | null>(null)
 
-    // Use user selection if available, otherwise use default
     const selectedHospital = userSelectedHospital || defaultSelectedHospital
 
-    // Handle hospital selection (click only, no hover)
     const handleHospitalClick = (hospital: EnrichedHospitalData) => {
         setUserSelectedHospital(hospital)
         if (onHospitalSelect) {
@@ -132,7 +140,6 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
         }
     }
 
-    // Handle map movement with geofence and zoom restrictions
     const onMove = useCallback((evt: { viewState: ViewState }) => {
         const newViewState = evt.viewState
         const newCenter = [newViewState.longitude, newViewState.latitude]
@@ -151,7 +158,6 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
 
     return (
         <div className="w-full h-full relative overflow-hidden">
-            {/* Map - full size */}
             <Map
                 reuseMaps
                 ref={mapRef}
@@ -161,10 +167,10 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
                 style={{ width: "100%", height: "100%" }}
                 onMove={onMove}
                 onLoad={() => {
-                    // Resize map after it loads to ensure proper fit
                     if (mapRef.current) {
                         setTimeout(() => {
                             mapRef.current?.resize()
+                            flyToUser()
                         }, 50)
                     }
                 }}
@@ -172,18 +178,38 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
                 minZoom={MIN_ZOOM}
                 maxZoom={MAX_ZOOM}
             >
-                {/* Language control - managed by useControl hook */}
                 <MapLanguageControl lang={lang} />
 
-                {/* User location marker (always shown) */}
-                {/* <Marker
-                    longitude={userLocation.longitude}
-                    latitude={userLocation.latitude}
-                    color="red"
-                    anchor="center"
-                /> */}
+                {userCoords && (
+                    <Marker
+                        longitude={userCoords.longitude}
+                        latitude={userCoords.latitude}
+                        anchor="center"
+                    >
+                        <div
+                            style={{
+                                width: "28px",
+                                height: "28px",
+                                backgroundColor: "#3b82f6",
+                                border: "2px solid white",
+                                borderRadius: "50%",
+                                boxShadow: "0 2px 4px rgba(0,0,0,0.3)",
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                transform: "translate(-50%, -50%)",
+                            }}
+                        >
+                            <User
+                                className="h-4 w-4 text-white"
+                                style={{
+                                    filter: "drop-shadow(0 1px 1px rgba(0,0,0,0.5))",
+                                }}
+                            />
+                        </div>
+                    </Marker>
+                )}
 
-                {/* Hospital markers */}
                 {enrichedHospitals.map((hospital) => {
                     const waitTime = getDisplayWaitTime(hospital)
                     const color = getWaitTimeColor(waitTime, currentTheme)
@@ -236,7 +262,6 @@ export function HospitalMap({ onHospitalSelect }: HospitalMapProps) {
                 })}
             </Map>
 
-            {/* Overlay info panel - always visible, positioned above map */}
             {selectedHospital && (
                 <HospitalMapOverlay
                     hospital={selectedHospital}

--- a/components/HospitalMap/HospitalMap.tsx
+++ b/components/HospitalMap/HospitalMap.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from "@/hooks/useLanguage"
 import { useMapboxDistance } from "@/hooks/useMapboxDistance"
 import {
     DEFAULT_COORDINATES,
+    findClosestHospital,
     getDisplayWaitTime,
     getWaitTimeColor,
     hasCriticalCases,
@@ -125,8 +126,8 @@ export function HospitalMap({
     )
 
     const defaultSelectedHospital = useMemo(() => {
-        return enrichedHospitals.length > 0 ? enrichedHospitals[0] : null
-    }, [enrichedHospitals])
+        return findClosestHospital(userLocation, enrichedHospitals)
+    }, [userLocation, enrichedHospitals])
 
     const [userSelectedHospital, setUserSelectedHospital] =
         useState<EnrichedHospitalData | null>(null)

--- a/components/HospitalMap/MapDialog.tsx
+++ b/components/HospitalMap/MapDialog.tsx
@@ -15,8 +15,8 @@ import { useLanguage } from "@/hooks/useLanguage"
 import { isUserInHongKong } from "@/lib/map"
 import { getLocalizedText, mapDialogTranslations } from "@/lib/map-translations"
 import { sendGAEvent } from "@next/third-parties/google"
-import { Map } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { LocateFixed, Map } from "lucide-react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useGeolocated } from "react-geolocated"
 
 export function MapDialog() {
@@ -27,36 +27,55 @@ export function MapDialog() {
         isGeolocationAvailable,
         isGeolocationEnabled,
         getPosition,
-    } = useGeolocated({ suppressLocationOnMount: true })
+    } = useGeolocated({
+        suppressLocationOnMount: true,
+        isOptimisticGeolocationEnabled: false,
+        watchLocationPermissionChange: true,
+    })
 
-    // Check if user is outside Hong Kong (Issue 8)
-    const isUserOutsideHongKong = useMemo(() => {
+    const rawCoords = useMemo(() => {
         if (isGeolocationEnabled && coords) {
-            return !isUserInHongKong({
+            return {
                 longitude: coords.longitude,
                 latitude: coords.latitude,
-            })
+            }
         }
-        return false
+        return null
     }, [isGeolocationEnabled, coords])
 
-    // Request geolocation when dialog opens
+    const isUserOutsideHongKong = useMemo(() => {
+        return rawCoords != null && !isUserInHongKong(rawCoords)
+    }, [rawCoords])
+
+    const userCoords =
+        rawCoords && !isUserOutsideHongKong ? rawCoords : null
+
+    const locationFeaturesEnabled =
+        isGeolocationEnabled && !isUserOutsideHongKong
+
+    const showLocateButton =
+        isGeolocationAvailable &&
+        !isUserOutsideHongKong &&
+        (!coords || !isGeolocationEnabled)
+
     useEffect(() => {
-        if (open && isGeolocationAvailable && !isGeolocationEnabled) {
-            // Try to get position when dialog opens
+        if (open && isGeolocationAvailable && !coords) {
             getPosition()
         }
-    }, [open, isGeolocationAvailable, isGeolocationEnabled, getPosition])
+    }, [open, isGeolocationAvailable, coords, getPosition])
 
     const handleClick = () => {
         sendGAEvent("event", "map_button_clicked")
-        // If geolocation is available but not enabled, try to get it
-        if (isGeolocationAvailable && !isGeolocationEnabled) {
+        if (isGeolocationAvailable && !coords) {
             getPosition()
         }
     }
 
-    // Show button even if geolocation is not available (map still works with default location)
+    const handleLocateMe = useCallback(() => {
+        sendGAEvent("event", "map_locate_me_clicked")
+        getPosition()
+    }, [getPosition])
+
     return (
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
@@ -85,16 +104,18 @@ export function MapDialog() {
                             mapDialogTranslations.description,
                             lang
                         )}
-                        {!isGeolocationEnabled && isGeolocationAvailable && (
-                            <span className="block mt-1 text-xs">
-                                {getLocalizedText(
-                                    mapDialogTranslations.noGeolocation,
-                                    lang
-                                )}
-                            </span>
-                        )}
+                        {!locationFeaturesEnabled &&
+                            isGeolocationAvailable &&
+                            !isUserOutsideHongKong && (
+                                <span className="block mt-1 text-xs">
+                                    {getLocalizedText(
+                                        mapDialogTranslations.noGeolocation,
+                                        lang
+                                    )}
+                                </span>
+                            )}
                         {isUserOutsideHongKong && (
-                            <span className="block mt-1 text-xs text-amber-600">
+                            <span className="block mt-1 text-xs text-amber-600 dark:text-amber-500">
                                 {getLocalizedText(
                                     mapDialogTranslations.outsideHongKong,
                                     lang
@@ -104,9 +125,25 @@ export function MapDialog() {
                     </DialogDescription>
                 </DialogHeader>
                 <div className="flex-1 w-full overflow-hidden px-6 pb-4">
-                    <HospitalMap />
+                    <HospitalMap userCoords={userCoords} isOpen={open} />
                 </div>
-                <DialogFooter className="px-6 pb-6">
+                <DialogFooter className="px-6 pb-6 flex-row justify-between sm:justify-between">
+                    {showLocateButton ? (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={handleLocateMe}
+                            className="gap-2"
+                        >
+                            <LocateFixed className="h-4 w-4" />
+                            {getLocalizedText(
+                                mapDialogTranslations.locateMe,
+                                lang
+                            )}
+                        </Button>
+                    ) : (
+                        <span />
+                    )}
                     <Button onClick={() => setOpen(false)}>Close</Button>
                 </DialogFooter>
             </DialogContent>

--- a/components/HospitalMap/MapDialog.tsx
+++ b/components/HospitalMap/MapDialog.tsx
@@ -12,6 +12,10 @@ import {
     DialogTrigger,
 } from "@/components/ui/dialog"
 import { useLanguage } from "@/hooks/useLanguage"
+import {
+    isGeolocationPermissionDenied,
+    useGeolocationPermissionState,
+} from "@/hooks/useGeolocationPermissionState"
 import { isUserInHongKong } from "@/lib/map"
 import { getLocalizedText, mapDialogTranslations } from "@/lib/map-translations"
 import { sendGAEvent } from "@next/third-parties/google"
@@ -26,12 +30,22 @@ export function MapDialog() {
         coords,
         isGeolocationAvailable,
         isGeolocationEnabled,
+        positionError,
         getPosition,
     } = useGeolocated({
         suppressLocationOnMount: true,
         isOptimisticGeolocationEnabled: false,
         watchLocationPermissionChange: true,
     })
+
+    const permissionState = useGeolocationPermissionState(
+        isGeolocationAvailable && open
+    )
+
+    const isLocationDenied = isGeolocationPermissionDenied(
+        positionError,
+        permissionState
+    )
 
     const rawCoords = useMemo(() => {
         if (isGeolocationEnabled && coords) {
@@ -104,9 +118,24 @@ export function MapDialog() {
                             mapDialogTranslations.description,
                             lang
                         )}
-                        {!locationFeaturesEnabled &&
+                        {isLocationDenied &&
                             isGeolocationAvailable &&
                             !isUserOutsideHongKong && (
+                                <span
+                                    className="block mt-1 text-xs text-amber-600 dark:text-amber-500"
+                                    role="status"
+                                    aria-live="polite"
+                                >
+                                    {getLocalizedText(
+                                        mapDialogTranslations.locationDenied,
+                                        lang
+                                    )}
+                                </span>
+                            )}
+                        {!locationFeaturesEnabled &&
+                            isGeolocationAvailable &&
+                            !isUserOutsideHongKong &&
+                            !isLocationDenied && (
                                 <span className="block mt-1 text-xs">
                                     {getLocalizedText(
                                         mapDialogTranslations.noGeolocation,

--- a/hooks/useGeolocationPermissionState.ts
+++ b/hooks/useGeolocationPermissionState.ts
@@ -1,0 +1,57 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+/**
+ * Reads the browser geolocation permission state when the Permissions API is available.
+ * Complements Geolocation API errors (e.g. after deny, before the next getCurrentPosition call).
+ */
+export function useGeolocationPermissionState(enabled: boolean) {
+    const [permissionState, setPermissionState] =
+        useState<PermissionState | null>(null)
+
+    useEffect(() => {
+        if (!enabled || typeof navigator === "undefined") {
+            return
+        }
+        if (!("permissions" in navigator)) {
+            return
+        }
+
+        let status: PermissionStatus | undefined
+
+        navigator.permissions
+            .query({ name: "geolocation" })
+            .then((result) => {
+                status = result
+                setPermissionState(result.state)
+                result.onchange = () => {
+                    setPermissionState(result.state)
+                }
+            })
+            .catch(() => {
+                // Permissions API unsupported or query failed (e.g. some Safari versions)
+            })
+
+        return () => {
+            if (status) {
+                status.onchange = null
+            }
+        }
+    }, [enabled])
+
+    return permissionState
+}
+
+/** GeolocationPositionError.PERMISSION_DENIED */
+export const GEOLOCATION_PERMISSION_DENIED = 1
+
+export function isGeolocationPermissionDenied(
+    positionError: GeolocationPositionError | undefined,
+    permissionState: PermissionState | null
+): boolean {
+    return (
+        positionError?.code === GEOLOCATION_PERMISSION_DENIED ||
+        permissionState === "denied"
+    )
+}

--- a/lib/map-translations.ts
+++ b/lib/map-translations.ts
@@ -37,6 +37,11 @@ export const mapDialogTranslations = {
         "啟用定位服務以查看與您位置的距離。",
         "启用定位服务以查看与您位置的距离。"
     ),
+    locationDenied: i18n(
+        "Location is blocked for this site. Allow it in your browser's site settings (lock icon in the address bar), then tap My location again.",
+        "此網站的定位已遭封鎖。請在瀏覽器網站設定（網址列鎖頭圖示）中允許定位，然後再按「我的位置」。",
+        "此网站的定位已被阻止。请在浏览器网站设置（地址栏锁头图标）中允许定位，然后再按「我的位置」。"
+    ),
     outsideHongKong: i18n(
         "You appear to be outside Hong Kong. Location features are disabled.",
         "您似乎不在香港。定位功能已停用。",

--- a/lib/map-translations.ts
+++ b/lib/map-translations.ts
@@ -38,10 +38,11 @@ export const mapDialogTranslations = {
         "启用定位服务以查看与您位置的距离。"
     ),
     outsideHongKong: i18n(
-        "You appear to be outside Hong Kong. Showing default location.",
-        "您似乎不在香港。顯示預設位置。",
-        "您似乎不在香港。显示预设位置。"
+        "You appear to be outside Hong Kong. Location features are disabled.",
+        "您似乎不在香港。定位功能已停用。",
+        "您似乎不在香港。定位功能已停用。"
     ),
+    locateMe: i18n("My location", "我的位置", "我的位置"),
 } as const
 
 // Management status texts (used in map overlay and table)

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -7,7 +7,12 @@ import {
     waitTimeCategoryLabels,
     waitTimeNA,
 } from "@/lib/map-translations"
-import { EnrichedHospitalData, LanguageCode, ManagementStatus } from "@/types"
+import {
+    Coordinates,
+    EnrichedHospitalData,
+    LanguageCode,
+    ManagementStatus,
+} from "@/types"
 import * as turf from "@turf/turf"
 
 type Theme = "light" | "dark"
@@ -78,6 +83,49 @@ export function isUserInHongKong(
     if (!coords) return false
     const point = [coords.longitude, coords.latitude]
     return turf.booleanPointInPolygon(point, HONG_KONG_GEOFENCE)
+}
+
+/**
+ * Find the hospital closest to a reference point (straight-line distance).
+ */
+export function findClosestHospital<T extends { coordinates: Coordinates }>(
+    reference: Coordinates,
+    hospitals: T[]
+): T | null {
+    if (hospitals.length === 0) return null
+
+    const origin: [number, number] = [
+        reference.longitude,
+        reference.latitude,
+    ]
+
+    let closest = hospitals[0]
+    let minDistance = turf.distance(
+        origin,
+        [
+            closest.coordinates.longitude,
+            closest.coordinates.latitude,
+        ],
+        { units: "kilometers" }
+    )
+
+    for (let i = 1; i < hospitals.length; i++) {
+        const hospital = hospitals[i]
+        const d = turf.distance(
+            origin,
+            [
+                hospital.coordinates.longitude,
+                hospital.coordinates.latitude,
+            ],
+            { units: "kilometers" }
+        )
+        if (d < minDistance) {
+            minDistance = d
+            closest = hospital
+        }
+    }
+
+    return closest
 }
 
 // ===================================================================================


### PR DESCRIPTION
## Issues

### Geolocation never requested

Opening the map modal did not show the browser location permission prompt. `getPosition()` was only called when `!isGeolocationEnabled`, but `react-geolocated` defaults `isOptimisticGeolocationEnabled` to `true`, so `isGeolocationEnabled` started as `true` on first render and the guard never ran.

### Duplicate geolocation hooks

`MapDialog` and `HospitalMap` each had their own `useGeolocated` instance. `HospitalMap` never called `getPosition()`, so even if the parent eventually requested location, the map component would not receive coordinates for the marker, distances, or panning.

### No user location marker

The user-location `Marker` was commented out, so there was no visual indication of the user’s position relative to hospitals.

### Map did not follow the user after granting location

`viewState` was initialized once and not updated when coordinates arrived after the permission prompt, so the map could stay centered on default coordinates.

### Poor UX after permission denial

After denying location, tapping My location called `getPosition()` but failed silently with no feedback. Browsers cannot re-show the system prompt after a deny; users must change site permissions manually, but the UI did not explain that.

### Outside Hong Kong behavior unclear

Users outside the Hong Kong geofence still saw generic messaging. Location features (marker, drive distances) should be disabled with explicit copy.

### Wrong default selected hospital

On open, the map always selected the first hospital in the list (Alice Ho Miu Ling Nethersole Hospital), regardless of map center or user location. That hospital was often off-screen when the map centered on the user or on default central Hong Kong coordinates.

* * *

## Updates

### Geolocation flow (`MapDialog`)

-   Single `useGeolocated` hook with `isOptimisticGeolocationEnabled: false` and `watchLocationPermissionChange: true`.
-   Request location when the map button is clicked or when the dialog opens if coordinates are not yet available (`!coords` instead of `!isGeolocationEnabled`).
-   Pass HK-only `userCoords` to `HospitalMap` (null when denied, unavailable, or outside the geofence).
-   Footer My location button (bottom-left, i18n) to retry with an explicit user gesture; hidden when location is active in HK or when the user is outside HK.

### Map behavior (`HospitalMap`)

-   Accept `userCoords` and `isOpen` from parent; remove local `useGeolocated`.
-   Blue User marker (28px, distinct from hospital wait-time dots) when `userCoords` is set.
-   One-time `flyTo` the user when coordinates arrive, with retry on map load; reset when the dialog closes.
-   Drive distances via Mapbox Matrix use `userCoords` as origin.

### Denied-permission UX

-   New `useGeolocationPermissionState` hook (Permissions API + `positionError`).
-   Amber `locationDenied` message (EN / 繁 / 简) explaining that permission must be allowed in browser site settings before My location will work again.
-   Generic `noGeolocation` hint only when permission is not yet denied.

### Copy and translations

-   `outsideHongKong`: location features are disabled (not “showing default location”).
-   `locateMe`: “My location” / 我的位置.

### Default hospital selection

-   New `findClosestHospital()` in `lib/map.ts` using Turf straight-line distance.
-   Default selected hospital is the one nearest to the user’s coordinates when available, otherwise nearest to `DEFAULT_COORDINATES`, so the overlay and selection ring match what is on screen when the map opens.
